### PR TITLE
Fix clock width when not in 24-hours

### DIFF
--- a/org.kde.plasma.chiliclock/contents/ui/DigitalClock.qml
+++ b/org.kde.plasma.chiliclock/contents/ui/DigitalClock.qml
@@ -161,7 +161,7 @@ Item {
             id: timeLabel
 
             height: sizehelper.height
-            width: !use24hFormat || use24hFormat === Qt.PartiallyChecked ? sizehelper.contentWidth - separator.paintedWidth : sizehelper.contentWidth
+            width: timeLabel.paintedWidth
             font: main.font
             fontSizeMode: fixedFont ? Text.FixedSize : Text.VerticalFit
             minimumPixelSize: 1


### PR DESCRIPTION
In many configurations, the clock width is not sufficient with the current method of calculating out the appropriate widget width, so the right side of the plasmoid is clipped as in issue #8. I have tried the suggestion in the reply by @qiaojunfeng and it works perfectly as far as I can tell with less complexity in the size calculations. I am also not experienced in plasmoid development, so would like to hear why this code was there initially and if this is the appropriate fix for the bug without introducing new bugs.

Fixes #8  