### PR TITLE
Add configurable background

### DIFF
--- a/org.kde.plasma.betterinlineclock/contents/ui/main.qml
+++ b/org.kde.plasma.betterinlineclock/contents/ui/main.qml
@@ -52,6 +52,7 @@ Item {
     Plasmoid.preferredRepresentation: Plasmoid.compactRepresentation
     Plasmoid.compactRepresentation: DigitalClock { }
     Plasmoid.fullRepresentation: CalendarView { }
+    Plasmoid.backgroundHints: PlasmaCore.Types.DefaultBackground | PlasmaCore.Types.ConfigurableBackground
 
     Plasmoid.toolTipItem: Loader {
         id: tooltipLoader


### PR DESCRIPTION
This problem described in #16.

I added property `Plasmoid.backgroundHints`, described in https://develop.kde.org/docs/plasma/widget/properties/ , to `main.qml` file. By default widget, placed on desktop, has default background, but user can configure this.